### PR TITLE
Update ecs-roles-cf.json

### DIFF
--- a/ecs-roles-cf.json
+++ b/ecs-roles-cf.json
@@ -16,6 +16,13 @@
                             ],
                             "Resource": [
                                 "arn:aws:ssm:*:*:parameter/*"
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "kms:Decrypt"
+                                    ],
+                                    "Resource": "arn:aws:kms:*:*:key/*"
+                                }
                             ]
                         }
                     ]


### PR DESCRIPTION
After working with internal team, found this additional permission was needed to handle KMS key backed secrets.  Allowing this in addition to @scott-hiemstra's 'Assumed' role changes gives us universal coverage.